### PR TITLE
fix: return email from JWT token verification

### DIFF
--- a/app/backend/src/database/Services/Auth/Jwt.auth.ts
+++ b/app/backend/src/database/Services/Auth/Jwt.auth.ts
@@ -17,11 +17,11 @@ export default class JWTService {
     return token;
   }
 
-  static tokenVerify = async (token: string) => {
+  static tokenVerify = async (token: string): Promise<string> => {
     const { newDataWithoutPassword } = jwt.verify(token, JWT_SECRET) as IPayload;
     const { email } = newDataWithoutPassword;
     if (!email) CustomError.badRequest('Token not found or expired');
-    return token;
+    return email;
   };
 
   static decode = async (token: string) => {


### PR DESCRIPTION
## Summary
- ensure JWT token verification returns the embedded email instead of the raw token

## Testing
- `npm test` *(fails: No test files found)*
- `node -r ts-node/register - <<'NODE'\nprocess.env.JWT_SECRET='test_secret';\nconst JWT = require('./src/database/Services/Auth/Jwt.auth').default;\nconst payload={id:1, username:'user', email:'user@example.com'};\nconst token=JWT.sign(payload);\nJWT.tokenVerify(token).then(email=>console.log('verified:', email));\nNODE`


------
https://chatgpt.com/codex/tasks/task_e_6897b01aead0832dae3dd79b1bf252f1